### PR TITLE
feat: safe execution mode with preflight policy checks

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -137,6 +137,20 @@ metadata: {"openclaw":{"requires":{"bins":["node"]}}}
 - **Get Session Key**: Query session key details (expiration, active status)
 - **Validate Session Key**: Check if a session key address is currently valid
 
+### Safe Execution Mode (v3.3)
+- **Preflight Check**: Query on-chain agent state before submitting any transaction
+  - Verifies agent exists and is active
+  - Checks required permission is granted
+  - Validates amount within per-tx limit (maxPerTx)
+  - Validates amount within remaining daily budget (dailyLimit − spentToday)
+  - Checks sufficient deposit balance
+  - Optionally validates session key is active and not expired
+- **Human-Readable Deny Reasons**: Returns clear explanations for each failed check
+- **Warnings**: Alerts for near-limit conditions (>80% daily budget, >90% deposit used)
+- **Dry-Run Mode**: Run all checks without submitting the transaction (`dryRun: true`)
+- **Safe Fund Agent**: `safeFundAgent()` — preflight + fund in one call
+- **Generic Safe Execute**: `safeExecute()` — preflight + arbitrary callback, blocks if policy denied
+
 ### AI Inference (v2.1)
 - **List Models**: Approved AI models from the on-chain registry (name, version, GPU tier)
 - **Inference Stats**: Network-wide statistics (tasks completed, active miners, avg time, FLOPS, pass rate)
@@ -464,6 +478,19 @@ Show info for agent "my-agent"
 List all agents owned by 0xfe913E97238B28abac7a55173f5878fD29147210
 ```
 
+### Safe Execution Mode
+```
+Check if agent "my-agent" can spend 50 QFC (dry run, don't submit)
+```
+
+```
+Safely fund agent "my-agent" with 20 QFC — check policy first, then submit if allowed
+```
+
+```
+Run preflight check for agent "my-agent" with Transfer permission and 5 QFC amount
+```
+
 ### Discord Bot
 ```
 Set up a QFC Discord bot using scripts/discord-bot-example.mjs as a template
@@ -489,3 +516,8 @@ Integrate QFCDiscordBot into my existing Discord bot to handle !balance and !fau
 | FEE_TOO_LOW | Max fee below minimum | Use estimateFee() to get base price |
 | AGENT_NOT_FOUND | Unknown agent ID | Check agentId, list agents with listAgents() |
 | SESSION_KEY_EXPIRED | Session key past expiry | Issue or rotate to a new session key |
+| PREFLIGHT_DENIED | Policy check failed | Inspect preflight.reasons[] for details |
+| DAILY_LIMIT_EXCEEDED | Amount exceeds remaining daily budget | Wait for daily reset or increase limit |
+| PER_TX_LIMIT_EXCEEDED | Amount exceeds per-transaction cap | Split into smaller transactions |
+| DEPOSIT_INSUFFICIENT | Agent deposit too low | Fund agent with fundAgent() |
+| PERMISSION_DENIED | Agent lacks required permission | Re-register with correct permissions |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qfc/openclaw-skill",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "QFC blockchain skill for AI agents — wallet management and chain interaction",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -48,6 +48,34 @@ export interface RegisterAgentResult extends AgentTxResult {
   agentId: string;
 }
 
+/** Reverse mapping from numeric permission to name */
+const PERMISSION_NAMES: Record<number, AgentPermission> = {
+  0: 'InferenceSubmit',
+  1: 'Transfer',
+  2: 'StakeDelegate',
+  3: 'QueryOnly',
+};
+
+/** Preflight check result — returned before tx submission */
+export interface PreflightResult {
+  allowed: boolean;
+  reasons: string[];
+  warnings: string[];
+  agent: AgentInfo | null;
+  sessionKeyValid?: boolean;
+}
+
+/** Options for preflight policy check */
+export interface PreflightOptions {
+  agentId: string;
+  /** Permission required for the operation */
+  requiredPermission?: AgentPermission;
+  /** Amount in QFC the operation will spend */
+  amountQFC?: string;
+  /** Session key address to validate (optional) */
+  sessionKeyAddress?: string;
+}
+
 /** Registry addresses per network */
 const REGISTRY_ADDRESS: Record<NetworkName, string> = {
   testnet: '0x7791dfa4d489f3d524708cbc0caa8689b76322b3',
@@ -399,5 +427,168 @@ export class QFCAgent {
 
     const contract = this.getContract(this.provider);
     return contract.isSessionKeyValid(keyAddress);
+  }
+
+  // ===================================================
+  // Safe Execution Mode — preflight policy checks
+  // ===================================================
+
+  /**
+   * Run preflight policy checks against on-chain state before submitting a tx.
+   * Returns whether the operation is allowed with human-readable deny reasons.
+   *
+   * Checks performed:
+   * - Agent exists and is active
+   * - Required permission is granted
+   * - Amount within per-tx limit (maxPerTx)
+   * - Amount within remaining daily budget (dailyLimit − spentToday)
+   * - Sufficient deposit balance
+   * - Session key validity (if provided)
+   */
+  async preflight(opts: PreflightOptions): Promise<PreflightResult> {
+    this.requireAgentId(opts.agentId);
+
+    const reasons: string[] = [];
+    const warnings: string[] = [];
+    let agent: AgentInfo | null = null;
+    let sessionKeyValid: boolean | undefined;
+
+    // 1. Fetch agent from chain
+    try {
+      agent = await this.getAgent(opts.agentId);
+    } catch {
+      return { allowed: false, reasons: [`Agent "${opts.agentId}" not found on-chain.`], warnings, agent: null };
+    }
+
+    // 2. Active check
+    if (!agent.active) {
+      reasons.push(`Agent "${opts.agentId}" is revoked/inactive.`);
+    }
+
+    // 3. Permission check
+    if (opts.requiredPermission) {
+      const requiredValue = PERMISSION_VALUES[opts.requiredPermission];
+      if (!agent.permissions.includes(requiredValue)) {
+        const granted = agent.permissions
+          .map((p) => PERMISSION_NAMES[p] ?? `unknown(${p})`)
+          .join(', ');
+        reasons.push(
+          `Missing permission "${opts.requiredPermission}". Agent has: [${granted}].`,
+        );
+      }
+    }
+
+    // 4. Amount checks (if spending QFC)
+    if (opts.amountQFC) {
+      const amount = parseFloat(opts.amountQFC);
+      const maxPerTx = parseFloat(agent.maxPerTx);
+      const dailyLimit = parseFloat(agent.dailyLimit);
+      const spentToday = parseFloat(agent.spentToday);
+      const deposit = parseFloat(agent.deposit);
+
+      if (amount > maxPerTx) {
+        reasons.push(
+          `Amount ${opts.amountQFC} QFC exceeds per-tx limit of ${agent.maxPerTx} QFC.`,
+        );
+      }
+
+      const remainingDaily = dailyLimit - spentToday;
+      if (amount > remainingDaily) {
+        reasons.push(
+          `Amount ${opts.amountQFC} QFC exceeds remaining daily budget of ${remainingDaily.toFixed(4)} QFC (limit: ${agent.dailyLimit}, spent: ${agent.spentToday}).`,
+        );
+      } else if (amount > remainingDaily * 0.8) {
+        warnings.push(
+          `This tx uses ${((amount / remainingDaily) * 100).toFixed(0)}% of remaining daily budget (${remainingDaily.toFixed(4)} QFC left).`,
+        );
+      }
+
+      if (amount > deposit) {
+        reasons.push(
+          `Insufficient deposit: ${agent.deposit} QFC available, ${opts.amountQFC} QFC required.`,
+        );
+      } else if (amount > deposit * 0.9) {
+        warnings.push(
+          `Deposit nearly depleted: ${agent.deposit} QFC remaining after this tx.`,
+        );
+      }
+    }
+
+    // 5. Session key check (if provided)
+    if (opts.sessionKeyAddress) {
+      this.requireAddress(opts.sessionKeyAddress, 'sessionKeyAddress');
+      try {
+        sessionKeyValid = await this.isSessionKeyValid(opts.sessionKeyAddress);
+        if (!sessionKeyValid) {
+          reasons.push(
+            `Session key ${opts.sessionKeyAddress} is expired or revoked.`,
+          );
+        }
+      } catch {
+        warnings.push(`Could not verify session key ${opts.sessionKeyAddress} (RPC error).`);
+      }
+    }
+
+    return {
+      allowed: reasons.length === 0,
+      reasons,
+      warnings,
+      agent,
+      sessionKeyValid,
+    };
+  }
+
+  /**
+   * Fund an agent with preflight policy checks (safe mode).
+   * In dry-run mode, returns the preflight result without submitting the tx.
+   */
+  async safeFundAgent(
+    ownerSigner: ethers.Signer,
+    agentId: string,
+    amountQFC: string,
+    opts?: { dryRun?: boolean; sessionKeyAddress?: string },
+  ): Promise<{ preflight: PreflightResult; tx?: AgentTxResult }> {
+    const check = await this.preflight({
+      agentId,
+      amountQFC,
+      requiredPermission: 'Transfer',
+      sessionKeyAddress: opts?.sessionKeyAddress,
+    });
+
+    if (opts?.dryRun || !check.allowed) {
+      return { preflight: check };
+    }
+
+    const tx = await this.fundAgent(ownerSigner, agentId, amountQFC);
+    return { preflight: check, tx };
+  }
+
+  /**
+   * Generic safe execution wrapper: run preflight, then execute a callback if allowed.
+   * In dry-run mode, returns the preflight result without executing.
+   *
+   * @example
+   * ```ts
+   * const result = await agent.safeExecute(
+   *   { agentId: 'my-agent', requiredPermission: 'Transfer', amountQFC: '5' },
+   *   async () => agent.fundAgent(signer, 'my-agent', '5'),
+   * );
+   * if (!result.preflight.allowed) {
+   *   console.log('Denied:', result.preflight.reasons);
+   * }
+   * ```
+   */
+  async safeExecute<T>(
+    opts: PreflightOptions & { dryRun?: boolean },
+    execute: () => Promise<T>,
+  ): Promise<{ preflight: PreflightResult; result?: T }> {
+    const check = await this.preflight(opts);
+
+    if (opts.dryRun || !check.allowed) {
+      return { preflight: check };
+    }
+
+    const result = await execute();
+    return { preflight: check, result };
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ export type { MulticallCall, MulticallResult, MulticallDeployResult } from './mu
 export { QFCEvents } from './events.js';
 export type { EventSubscription, TransferEvent, SwapEvent, BlockEvent } from './events.js';
 export { QFCAgent } from './agent.js';
-export type { AgentPermission, AgentInfo, SessionKeyInfo, AgentTxResult, RegisterAgentResult } from './agent.js';
+export type { AgentPermission, AgentInfo, SessionKeyInfo, AgentTxResult, RegisterAgentResult, PreflightResult, PreflightOptions } from './agent.js';
 export { QFCDiscordBot } from './discord.js';
 export type { BotCommand, BotResponse } from './discord.js';
 export { QFCMinerMonitor } from './miner-monitor.js';


### PR DESCRIPTION
## Summary
- **`preflight()`** — query on-chain agent state before tx submission; checks agent exists/active, required permission granted, amount within per-tx and daily limits, sufficient deposit, optional session key validity
- **`safeExecute()`** — generic wrapper: run preflight, execute callback only if allowed; supports `dryRun: true` for approval previews
- **`safeFundAgent()`** — convenience method combining preflight + fundAgent in one call
- **Human-readable deny reasons** — clear `reasons[]` array explaining each failed check
- **Near-limit warnings** — alerts when >80% daily budget or >90% deposit consumed
- **New exported types**: `PreflightResult`, `PreflightOptions`
- **SKILL.md**: Safe Execution Mode docs, usage examples, error codes
- **Version bump**: 3.2.0 → 3.3.0

Closes #33

## Changed files
- `src/agent.ts` — preflight(), safeExecute(), safeFundAgent(), types
- `src/index.ts` — barrel exports for PreflightResult, PreflightOptions
- `SKILL.md` — safe execution docs, examples, error codes
- `package.json` — version 3.3.0

## Test plan
- [ ] `npm run build` passes (verified locally)
- [ ] preflight() returns `allowed: false` with reasons for inactive agent
- [ ] preflight() returns `allowed: false` for missing permission
- [ ] preflight() returns `allowed: false` when amount > maxPerTx or dailyLimit
- [ ] preflight() returns warnings when near limits (>80% daily, >90% deposit)
- [ ] safeExecute() with `dryRun: true` returns preflight without executing
- [ ] safeExecute() blocks execution when preflight denies

🤖 Generated with [Claude Code](https://claude.com/claude-code)