### PR TITLE
feat: AgentWalletClient — session-key inference & demo scenarios

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ src/
   staking.ts        — QFCStaking: validators, stake, scores
   epoch.ts          — QFCEpoch: epoch & finality
   inference.ts      — QFCInference: AI inference tasks
+  agent-wallet.ts   — AgentWalletClient: session-key-aware agent operations
   contract.ts       — QFCContract: read/write/deploy/verify contracts
   token.ts          — QFCToken: ERC-20 deploy/transfer/mint/burn/airdrop
   swap.ts           — QFCSwap: AMM token swap + WQFC wrapper

--- a/SKILL.md
+++ b/SKILL.md
@@ -151,6 +151,15 @@ metadata: {"openclaw":{"requires":{"bins":["node"]}}}
 - **Safe Fund Agent**: `safeFundAgent()` — preflight + fund in one call
 - **Generic Safe Execute**: `safeExecute()` — preflight + arbitrary callback, blocks if policy denied
 
+### Agent Wallet Client (v3.4)
+- **AgentWalletClient**: High-level client wrapping QFCAgent + QFCInference for autonomous agent operations
+- **Session-Key Inference**: Submit inference tasks using a session key instead of the owner's long-lived private key — the on-chain registry validates the session key's permissions and spending limits
+- **Preflight-Guarded Submission**: Automatically runs preflight policy checks before every inference submission (permission, daily budget, deposit balance, session key validity)
+- **Full Agent Lifecycle**: register, fund, revoke, status, list — all through a single client
+- **Session Key Management**: issue, rotate, revoke, validate session keys
+- **Fee Estimation**: Estimate inference cost before submission
+- **Demo Scenarios**: Autonomous Trader, Content Generator, AI Oracle — see `scripts/demo-*.mjs`
+
 ### AI Inference (v2.1)
 - **List Models**: Approved AI models from the on-chain registry (name, version, GPU tier)
 - **Inference Stats**: Network-wide statistics (tasks completed, active miners, avg time, FLOPS, pass rate)
@@ -196,6 +205,7 @@ Mainnet RPC: https://rpc.qfc.network (chain ID: 9001)
 | `multicall` | `QFCMulticall` | Batch contract reads in single RPC |
 | `events` | `QFCEvents` | Event subscriptions via polling |
 | `agent` | `QFCAgent` | AI agent registry — register, fund, revoke, session keys |
+| `agent-wallet` | `AgentWalletClient` | High-level agent wallet — session-key inference, lifecycle, safe execution |
 | `inference` | `QFCInference` | AI inference task submission & results |
 | `provider` | — | Shared provider creation & RPC helper |
 
@@ -489,6 +499,23 @@ Safely fund agent "my-agent" with 20 QFC — check policy first, then submit if 
 
 ```
 Run preflight check for agent "my-agent" with Transfer permission and 5 QFC amount
+```
+
+### Agent Wallet Client
+```
+Create an autonomous trader agent: register "trader-1" with InferenceSubmit and Transfer permissions, 100 QFC daily limit, issue a session key, then submit a sentiment analysis inference using only the session key
+```
+
+```
+Set up a content generator agent with InferenceSubmit-only permission and a 7-day session key
+```
+
+```
+Run an AI oracle: register agent, estimate inference fee, run preflight check, then submit a query — all using the session key
+```
+
+```
+Submit an inference task as agent "my-agent" using session key — model qfc-embed-small, input "Hello world"
 ```
 
 ### Discord Bot

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qfc/openclaw-skill",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "QFC blockchain skill for AI agents — wallet management and chain interaction",
   "type": "module",
   "main": "./dist/index.js",

--- a/scripts/demo-ai-oracle.mjs
+++ b/scripts/demo-ai-oracle.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Demo: AI Oracle Agent
+ *
+ * Shows how an AI agent can answer on-chain queries:
+ * 1. Register with InferenceSubmit + QueryOnly permissions
+ * 2. Estimate fees before submitting
+ * 3. Submit queries and decode results
+ * 4. Monitor spending with preflight checks
+ *
+ * In production, a paymaster would sponsor gas so the agent
+ * doesn't need to hold QFC directly (M2 feature).
+ *
+ * Usage:
+ *   export OWNER_PRIVATE_KEY=0x...
+ *   node scripts/demo-ai-oracle.mjs
+ */
+
+import { ethers } from 'ethers';
+import { AgentWalletClient } from '../dist/agent-wallet.js';
+
+const NETWORK = 'testnet';
+
+async function main() {
+  const ownerKey = process.env.OWNER_PRIVATE_KEY;
+  if (!ownerKey) {
+    console.error('Set OWNER_PRIVATE_KEY environment variable');
+    process.exit(1);
+  }
+
+  const ownerWallet = new ethers.Wallet(ownerKey);
+  const sessionWallet = ethers.Wallet.createRandom();
+
+  console.log(`Owner: ${ownerWallet.address}`);
+  console.log(`Oracle session key: ${sessionWallet.address}`);
+
+  const client = new AgentWalletClient(NETWORK);
+
+  // --- Register oracle agent ---
+
+  console.log('\n[1/5] Registering oracle agent...');
+  const reg = await client.register(ownerWallet, {
+    agentId: 'oracle-1',
+    agentAddress: sessionWallet.address,
+    permissions: ['InferenceSubmit', 'QueryOnly'],
+    dailyLimitQFC: '50',
+    maxPerTxQFC: '5',
+    depositQFC: '25',
+  });
+  console.log(`Registered: ${reg.explorerUrl}`);
+
+  await client.issueSessionKey(ownerWallet, {
+    agentId: 'oracle-1',
+    sessionKeyAddress: sessionWallet.address,
+    durationSeconds: 86400 * 3, // 3 days
+  });
+  console.log('Session key issued (3 day TTL)');
+
+  // --- Oracle operates ---
+
+  const oracle = new AgentWalletClient(NETWORK, {
+    privateKey: sessionWallet.privateKey,
+    agentId: 'oracle-1',
+  });
+
+  // Estimate fee first
+  console.log('\n[2/5] Estimating fee...');
+  const fee = await oracle.estimateFee('qfc-embed-small', 'TextEmbedding');
+  console.log(`  Base fee: ${fee.baseFee} QFC`);
+  console.log(`  GPU tier: ${fee.gpuTier}`);
+  console.log(`  Est. time: ${fee.estimatedTimeMs}ms`);
+
+  // Preflight check before spending
+  console.log('\n[3/5] Preflight check...');
+  const check = await oracle.preflight('oracle-1', {
+    requiredPermission: 'InferenceSubmit',
+    amountQFC: fee.baseFee,
+  });
+  console.log(`  Allowed: ${check.allowed}`);
+  if (check.warnings.length > 0) {
+    console.log(`  Warnings: ${check.warnings.join('; ')}`);
+  }
+
+  // Answer a query
+  console.log('\n[4/5] Answering query via inference...');
+  const result = await oracle.submitInference(
+    'qfc-embed-small',
+    'TextEmbedding',
+    'What is the current gas price trend on QFC network?',
+    '1',
+  );
+  console.log(`Task: ${result.taskId} — Status: ${result.status.status}`);
+
+  // Check remaining budget
+  console.log('\n[5/5] Agent spending report:');
+  const info = await oracle.status('oracle-1');
+  console.log(`  Deposit remaining: ${info.deposit} QFC`);
+  console.log(`  Spent today: ${info.spentToday} QFC`);
+  console.log(`  Daily budget left: ${(parseFloat(info.dailyLimit) - parseFloat(info.spentToday)).toFixed(4)} QFC`);
+
+  console.log('\nDemo complete.');
+}
+
+main().catch((err) => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/scripts/demo-autonomous-trader.mjs
+++ b/scripts/demo-autonomous-trader.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * Demo: Autonomous Trader Agent
+ *
+ * Shows how an AI agent can:
+ * 1. Be registered by an owner with Transfer + InferenceSubmit permissions
+ * 2. Receive a session key (no owner key needed after this point)
+ * 3. Run sentiment analysis via inference
+ * 4. Execute trades based on results
+ *
+ * Usage:
+ *   export OWNER_PRIVATE_KEY=0x...
+ *   node scripts/demo-autonomous-trader.mjs
+ */
+
+import { ethers } from 'ethers';
+import { AgentWalletClient } from '../dist/agent-wallet.js';
+
+const NETWORK = 'testnet';
+
+async function main() {
+  const ownerKey = process.env.OWNER_PRIVATE_KEY;
+  if (!ownerKey) {
+    console.error('Set OWNER_PRIVATE_KEY environment variable');
+    process.exit(1);
+  }
+
+  const ownerWallet = new ethers.Wallet(ownerKey);
+  console.log(`Owner: ${ownerWallet.address}`);
+
+  // --- Phase 1: Owner sets up the agent ---
+
+  const client = new AgentWalletClient(NETWORK);
+
+  // Generate a session key for the agent
+  const sessionWallet = ethers.Wallet.createRandom();
+  console.log(`Session key address: ${sessionWallet.address}`);
+
+  // Register the agent
+  console.log('\n[1/4] Registering agent...');
+  const reg = await client.register(ownerWallet, {
+    agentId: 'trader-1',
+    agentAddress: sessionWallet.address,
+    permissions: ['InferenceSubmit', 'Transfer'],
+    dailyLimitQFC: '100',
+    maxPerTxQFC: '10',
+    depositQFC: '50',
+  });
+  console.log(`Registered: ${reg.explorerUrl}`);
+
+  // Issue session key (valid for 24 hours)
+  console.log('\n[2/4] Issuing session key...');
+  const keyTx = await client.issueSessionKey(ownerWallet, {
+    agentId: 'trader-1',
+    sessionKeyAddress: sessionWallet.address,
+    durationSeconds: 86400,
+  });
+  console.log(`Session key issued: ${keyTx.explorerUrl}`);
+
+  // --- Phase 2: Agent operates autonomously ---
+
+  const agentClient = new AgentWalletClient(NETWORK, {
+    privateKey: sessionWallet.privateKey,
+    agentId: 'trader-1',
+  });
+
+  // Run sentiment analysis
+  console.log('\n[3/4] Submitting inference (sentiment analysis)...');
+  const result = await agentClient.submitInference(
+    'qfc-embed-small',
+    'TextEmbedding',
+    'Bitcoin price surging, market sentiment very bullish, institutional buying detected',
+    '0.1',
+  );
+  console.log(`Task: ${result.taskId} — Status: ${result.status.status}`);
+  if (result.decoded) {
+    console.log('Result:', JSON.stringify(result.decoded.output, null, 2));
+  }
+
+  // Check agent status
+  console.log('\n[4/4] Agent status:');
+  const info = await agentClient.status('trader-1');
+  console.log(`  Active: ${info.active}`);
+  console.log(`  Deposit: ${info.deposit} QFC`);
+  console.log(`  Spent today: ${info.spentToday} QFC`);
+  console.log(`  Daily limit: ${info.dailyLimit} QFC`);
+
+  console.log('\nDemo complete.');
+}
+
+main().catch((err) => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/scripts/demo-content-generator.mjs
+++ b/scripts/demo-content-generator.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * Demo: Content Generator Agent
+ *
+ * Shows how an AI agent with INFERENCE-only permission can:
+ * 1. Be registered with minimal permissions (InferenceSubmit only)
+ * 2. Generate content on a schedule using session keys
+ * 3. Cannot transfer funds (permission denied)
+ *
+ * Usage:
+ *   export OWNER_PRIVATE_KEY=0x...
+ *   node scripts/demo-content-generator.mjs
+ */
+
+import { ethers } from 'ethers';
+import { AgentWalletClient } from '../dist/agent-wallet.js';
+
+const NETWORK = 'testnet';
+
+async function main() {
+  const ownerKey = process.env.OWNER_PRIVATE_KEY;
+  if (!ownerKey) {
+    console.error('Set OWNER_PRIVATE_KEY environment variable');
+    process.exit(1);
+  }
+
+  const ownerWallet = new ethers.Wallet(ownerKey);
+  const sessionWallet = ethers.Wallet.createRandom();
+
+  console.log(`Owner: ${ownerWallet.address}`);
+  console.log(`Session key: ${sessionWallet.address}`);
+
+  // --- Owner setup ---
+
+  const client = new AgentWalletClient(NETWORK);
+
+  console.log('\n[1/3] Registering content-gen agent (InferenceSubmit only)...');
+  const reg = await client.register(ownerWallet, {
+    agentId: 'content-gen-1',
+    agentAddress: sessionWallet.address,
+    permissions: ['InferenceSubmit'],  // No Transfer!
+    dailyLimitQFC: '10',
+    maxPerTxQFC: '1',
+    depositQFC: '5',
+  });
+  console.log(`Registered: ${reg.explorerUrl}`);
+
+  await client.issueSessionKey(ownerWallet, {
+    agentId: 'content-gen-1',
+    sessionKeyAddress: sessionWallet.address,
+    durationSeconds: 86400 * 7, // 7 days
+  });
+  console.log('Session key issued (7 day TTL)');
+
+  // --- Agent generates content ---
+
+  const agentClient = new AgentWalletClient(NETWORK, {
+    privateKey: sessionWallet.privateKey,
+    agentId: 'content-gen-1',
+  });
+
+  console.log('\n[2/3] Generating content via inference...');
+  const result = await agentClient.submitInference(
+    'qfc-embed-small',
+    'TextGeneration',
+    'Write a short blog post about decentralized AI compute networks',
+    '0.5',
+  );
+  console.log(`Task: ${result.taskId} — Status: ${result.status.status}`);
+
+  // --- Verify Transfer permission is denied ---
+
+  console.log('\n[3/3] Testing Transfer permission (should be denied)...');
+  const check = await agentClient.preflight('content-gen-1', {
+    requiredPermission: 'Transfer',
+    amountQFC: '1',
+  });
+  console.log(`Transfer allowed: ${check.allowed}`);
+  if (!check.allowed) {
+    console.log(`Denied reasons: ${check.reasons.join('; ')}`);
+  }
+
+  console.log('\nDemo complete.');
+}
+
+main().catch((err) => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/src/agent-wallet.ts
+++ b/src/agent-wallet.ts
@@ -1,0 +1,330 @@
+import { ethers } from 'ethers';
+import { NetworkName, createProvider, rpcCall } from './provider.js';
+import {
+  QFCAgent,
+  AgentInfo,
+  AgentTxResult,
+  RegisterAgentResult,
+  AgentPermission,
+  SessionKeyInfo,
+  PreflightResult,
+} from './agent.js';
+import { QFCInference, InferenceTaskStatus, DecodedResult, FeeEstimate } from './inference.js';
+
+/** Options for registering a new agent */
+export interface RegisterAgentOptions {
+  agentId: string;
+  agentAddress: string;
+  permissions: AgentPermission[];
+  dailyLimitQFC: string;
+  maxPerTxQFC: string;
+  depositQFC: string;
+}
+
+/** Session key configuration for the client */
+export interface SessionKeyConfig {
+  /** Private key of the session key (hex) */
+  privateKey: string;
+  /** Agent ID this session key belongs to */
+  agentId: string;
+}
+
+/** Options for issuing a session key */
+export interface IssueSessionKeyOptions {
+  agentId: string;
+  /** Address of the session key (derived from its private key) */
+  sessionKeyAddress: string;
+  /** Duration in seconds */
+  durationSeconds: number;
+}
+
+/** Result from session-key-aware inference submission */
+export interface AgentInferenceResult {
+  taskId: string;
+  status: InferenceTaskStatus;
+  decoded?: DecodedResult;
+}
+
+/**
+ * AgentWalletClient — high-level client for AI agent wallet operations.
+ *
+ * Wraps QFCAgent (on-chain registry) and QFCInference (task submission)
+ * to enable session-key-aware operations. An agent can submit inference
+ * tasks using a session key instead of the owner's long-lived private key.
+ *
+ * @example
+ * ```ts
+ * // Owner registers agent and issues session key
+ * const client = new AgentWalletClient('testnet');
+ * const ownerWallet = new ethers.Wallet(OWNER_KEY);
+ * await client.register(ownerWallet, {
+ *   agentId: 'trader-1',
+ *   agentAddress: sessionWallet.address,
+ *   permissions: ['InferenceSubmit', 'Transfer'],
+ *   dailyLimitQFC: '100',
+ *   maxPerTxQFC: '10',
+ *   depositQFC: '50',
+ * });
+ * await client.issueSessionKey(ownerWallet, {
+ *   agentId: 'trader-1',
+ *   sessionKeyAddress: sessionWallet.address,
+ *   durationSeconds: 86400,
+ * });
+ *
+ * // Agent operates autonomously with session key (no owner key needed)
+ * const agentClient = new AgentWalletClient('testnet', {
+ *   privateKey: SESSION_PRIVATE_KEY,
+ *   agentId: 'trader-1',
+ * });
+ * const result = await agentClient.submitInference(
+ *   'qfc-embed-small', 'TextEmbedding', 'analyze market sentiment', '0.1',
+ * );
+ * ```
+ */
+export class AgentWalletClient {
+  private agent: QFCAgent;
+  private inference: QFCInference;
+  private network: NetworkName;
+  private sessionKey?: SessionKeyConfig;
+  private sessionWallet?: ethers.Wallet;
+
+  constructor(network: NetworkName = 'testnet', sessionKey?: SessionKeyConfig) {
+    this.network = network;
+    this.agent = new QFCAgent(network);
+    this.inference = new QFCInference(network);
+
+    if (sessionKey) {
+      this.sessionKey = sessionKey;
+      this.sessionWallet = new ethers.Wallet(sessionKey.privateKey);
+    }
+  }
+
+  // ===================================================
+  // Agent Lifecycle (owner operations)
+  // ===================================================
+
+  /** Register a new agent on-chain. Requires owner signer. */
+  async register(
+    ownerSigner: ethers.Signer,
+    opts: RegisterAgentOptions,
+  ): Promise<RegisterAgentResult> {
+    return this.agent.registerAgent(
+      ownerSigner,
+      opts.agentId,
+      opts.agentAddress,
+      opts.permissions,
+      opts.dailyLimitQFC,
+      opts.maxPerTxQFC,
+      opts.depositQFC,
+    );
+  }
+
+  /** Fund an agent with additional QFC. Requires owner signer. */
+  async fund(
+    ownerSigner: ethers.Signer,
+    agentId: string,
+    amountQFC: string,
+  ): Promise<AgentTxResult> {
+    return this.agent.fundAgent(ownerSigner, agentId, amountQFC);
+  }
+
+  /** Revoke an agent, deactivating it. Requires owner signer. */
+  async revoke(
+    ownerSigner: ethers.Signer,
+    agentId: string,
+  ): Promise<AgentTxResult> {
+    return this.agent.revokeAgent(ownerSigner, agentId);
+  }
+
+  /** Get agent info by ID. */
+  async status(agentId: string): Promise<AgentInfo> {
+    return this.agent.getAgent(agentId);
+  }
+
+  /** List all agent IDs owned by an address. */
+  async list(ownerAddress: string): Promise<string[]> {
+    return this.agent.listAgents(ownerAddress);
+  }
+
+  // ===================================================
+  // Session Key Management (owner operations)
+  // ===================================================
+
+  /** Issue a session key for an agent. Requires owner signer. */
+  async issueSessionKey(
+    ownerSigner: ethers.Signer,
+    opts: IssueSessionKeyOptions,
+  ): Promise<AgentTxResult> {
+    return this.agent.issueSessionKey(
+      ownerSigner,
+      opts.agentId,
+      opts.sessionKeyAddress,
+      opts.durationSeconds,
+    );
+  }
+
+  /** Rotate a session key: revoke old, issue new. Requires owner signer. */
+  async rotateSessionKey(
+    ownerSigner: ethers.Signer,
+    agentId: string,
+    oldKeyAddress: string,
+    newKeyAddress: string,
+    durationSeconds: number,
+  ): Promise<AgentTxResult> {
+    return this.agent.rotateSessionKey(
+      ownerSigner,
+      agentId,
+      oldKeyAddress,
+      newKeyAddress,
+      durationSeconds,
+    );
+  }
+
+  /** Revoke a session key. Requires owner signer. */
+  async revokeSessionKey(
+    ownerSigner: ethers.Signer,
+    agentId: string,
+    keyAddress: string,
+  ): Promise<AgentTxResult> {
+    return this.agent.revokeSessionKey(ownerSigner, agentId, keyAddress);
+  }
+
+  /** Get session key info. */
+  async getSessionKey(agentId: string, keyAddress: string): Promise<SessionKeyInfo> {
+    return this.agent.getSessionKey(agentId, keyAddress);
+  }
+
+  /** Check if a session key is still valid. */
+  async isSessionKeyValid(keyAddress: string): Promise<boolean> {
+    return this.agent.isSessionKeyValid(keyAddress);
+  }
+
+  // ===================================================
+  // Session-Key-Aware Inference (agent operations)
+  // ===================================================
+
+  /**
+   * Submit an inference task using the session key (no owner key needed).
+   *
+   * The task is signed by the session key wallet. The on-chain registry
+   * validates that the session key is authorized for the agent and has
+   * the InferenceSubmit permission.
+   *
+   * @param modelId - Model ID (e.g. "qfc-embed-small")
+   * @param taskType - Task type (e.g. "TextEmbedding", "TextGeneration")
+   * @param input - Input text
+   * @param maxFeeQFC - Maximum fee in QFC
+   * @param opts - Optional: waitForResult (default true), timeoutMs
+   */
+  async submitInference(
+    modelId: string,
+    taskType: string,
+    input: string,
+    maxFeeQFC: string,
+    opts?: { waitForResult?: boolean; timeoutMs?: number },
+  ): Promise<AgentInferenceResult> {
+    if (!this.sessionKey || !this.sessionWallet) {
+      throw new Error(
+        'No session key configured. Create AgentWalletClient with a SessionKeyConfig to use session-key inference.',
+      );
+    }
+
+    // Preflight: verify agent is active and session key is valid
+    const preflight = await this.agent.preflight({
+      agentId: this.sessionKey.agentId,
+      requiredPermission: 'InferenceSubmit',
+      amountQFC: maxFeeQFC,
+      sessionKeyAddress: this.sessionWallet.address,
+    });
+
+    if (!preflight.allowed) {
+      throw new Error(
+        `Preflight denied: ${preflight.reasons.join('; ')}`,
+      );
+    }
+
+    // Submit task signed by the session key wallet
+    const provider = createProvider(this.network);
+    const connectedWallet = this.sessionWallet.connect(provider);
+    const taskId = await this.inference.submitTask(
+      modelId,
+      taskType,
+      input,
+      maxFeeQFC,
+      connectedWallet,
+    );
+
+    // Optionally wait for result
+    const shouldWait = opts?.waitForResult !== false;
+    if (shouldWait) {
+      const status = await this.inference.waitForResult(
+        taskId,
+        opts?.timeoutMs ?? 120_000,
+      );
+      let decoded: DecodedResult | undefined;
+      if (status.status === 'Completed' && status.result) {
+        try {
+          decoded = this.inference.decodeResult(status.result);
+        } catch {
+          // result may be in IPFS — caller can fetch separately
+        }
+      }
+      return { taskId, status, decoded };
+    }
+
+    const status = await this.inference.getTaskStatus(taskId);
+    return { taskId, status };
+  }
+
+  /** Estimate fee for an inference task. */
+  async estimateFee(
+    modelId: string,
+    taskType?: string,
+    inputSize?: number,
+  ): Promise<FeeEstimate> {
+    return this.inference.estimateFee(modelId, taskType, inputSize);
+  }
+
+  /** Get the session key wallet address (if configured). */
+  get sessionKeyAddress(): string | undefined {
+    return this.sessionWallet?.address;
+  }
+
+  /** Get the agent ID associated with the session key (if configured). */
+  get agentId(): string | undefined {
+    return this.sessionKey?.agentId;
+  }
+
+  // ===================================================
+  // Safe Execution (preflight + execute)
+  // ===================================================
+
+  /** Run preflight checks without submitting. */
+  async preflight(agentId: string, opts?: {
+    requiredPermission?: AgentPermission;
+    amountQFC?: string;
+    sessionKeyAddress?: string;
+  }): Promise<PreflightResult> {
+    return this.agent.preflight({
+      agentId,
+      ...opts,
+      sessionKeyAddress: opts?.sessionKeyAddress ?? this.sessionWallet?.address,
+    });
+  }
+
+  /**
+   * Safely fund an agent: run preflight checks, then fund if allowed.
+   * In dry-run mode, returns only the preflight result.
+   */
+  async safeFund(
+    ownerSigner: ethers.Signer,
+    agentId: string,
+    amountQFC: string,
+    opts?: { dryRun?: boolean },
+  ): Promise<{ preflight: PreflightResult; tx?: AgentTxResult }> {
+    return this.agent.safeFundAgent(ownerSigner, agentId, amountQFC, {
+      dryRun: opts?.dryRun,
+      sessionKeyAddress: this.sessionWallet?.address,
+    });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,8 @@ export { QFCEvents } from './events.js';
 export type { EventSubscription, TransferEvent, SwapEvent, BlockEvent } from './events.js';
 export { QFCAgent } from './agent.js';
 export type { AgentPermission, AgentInfo, SessionKeyInfo, AgentTxResult, RegisterAgentResult, PreflightResult, PreflightOptions } from './agent.js';
+export { AgentWalletClient } from './agent-wallet.js';
+export type { RegisterAgentOptions, SessionKeyConfig, IssueSessionKeyOptions, AgentInferenceResult } from './agent-wallet.js';
 export { QFCDiscordBot } from './discord.js';
 export type { BotCommand, BotResponse } from './discord.js';
 export { QFCMinerMonitor } from './miner-monitor.js';


### PR DESCRIPTION
## Summary
- Add `AgentWalletClient` class (`src/agent-wallet.ts`) — high-level client wrapping `QFCAgent` + `QFCInference` for autonomous agent operations
- Session-key-aware inference: agents submit tasks signed by session key (no owner key needed), with automatic preflight policy checks
- Three demo scripts: Autonomous Trader, Content Generator, AI Oracle (`scripts/demo-*.mjs`)
- Bump version to 3.4.0

## Test plan
- [ ] `npm run build` passes cleanly
- [ ] `AgentWalletClient` instantiates with and without session key config
- [ ] `submitInference()` runs preflight before submission and rejects if denied
- [ ] Demo scripts run end-to-end on testnet with a funded wallet
- [ ] Existing `QFCAgent` tests still pass

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)